### PR TITLE
[23] feat: add Tailwind v4 integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "cSpell.words": ["bigdecimal", "evenodd", "github", "imagotype", "jekyll"]
+  "cSpell.words": [
+    "bigdecimal",
+    "evenodd",
+    "github",
+    "imagotype",
+    "jekyll",
+    "svgpack"
+  ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 MarsBased
+Copyright (c) 2026 Javier Artero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # svgpack
 
-# [![svgpack](https://raw.githubusercontent.com/MarsBased/svgpack/main/docs/svgpack-logo.svg)](https://svgpack.javierartero.com)
+# [![svgpack](https://raw.githubusercontent.com/javierartero/svgpack/main/docs/svgpack-logo.svg)](https://svgpack.javierartero.com)
 
-[![npm](https://img.shields.io/npm/v/@marsbased/svgpack.svg?style=flat-square)](https://www.npmjs.com/package/@marsbased/svgpack)
+[![npm](https://img.shields.io/npm/v/@artero/svgpack.svg?style=flat-square)](https://www.npmjs.com/package/@artero/svgpack)
 
 ## Documentation
 
@@ -10,7 +10,7 @@
 
 `svgpack` converts SVG files into CSS variables and ready-to-use classes.
 
-It optimizes and sanitizes SVGs and generates CSS variables for direct use, plus optional CSS classes for easy implementation. Perfect for modern web development with frameworks like Remix, NextJS, and vanilla CSS.
+It optimizes and sanitizes SVGs and generates CSS variables for direct use, plus optional CSS classes for easy implementation. Perfect for modern web development with frameworks like Angular, NextJS, and vanilla CSS.
 
 **Why CSS Variables over Direct SVG?**
 
@@ -39,6 +39,7 @@ Instead of embedding SVG code directly in your HTML (which downloads the entire 
 - [Quick Start](https://svgpack.javierartero.com/quick-start/)
 - [CLI Usage](https://svgpack.javierartero.com/cli-usage/)
 - [CSS Variables Usage](https://svgpack.javierartero.com/css-variables/)
+- [Tailwind v4](https://svgpack.javierartero.com/tailwind-v4/)
 - [SCSS Functions](https://svgpack.javierartero.com/scss-functions/)
 - [React Components](https://svgpack.javierartero.com/react-components/)
 - [Installation](https://svgpack.javierartero.com/installation/)
@@ -48,8 +49,10 @@ Instead of embedding SVG code directly in your HTML (which downloads the entire 
 ### Install as Project Dependency (Recommended)
 
 ```bash
-npm install @marsbased/svgpack
+npm install -D @artero/svgpack
 ```
+
+⚠️ **Previously published as @marsbased/svgpack.** The old package is deprecated and will no longer receive updates.
 
 ### CLI Usage
 
@@ -63,9 +66,17 @@ svgpack my-images/ --background --mask > images.css
 # SCSS functions instead of CSS variables
 svgpack my-images/ --sass > images.scss
 
+# Tailwind v4 native output
+svgpack my-images/ --tailwind > theme.css
+
 # Get help
 svgpack --help
 ```
+
+## Origins
+
+Originally developed at [MarsBased](https://github.com/orgs/MarsBased) by [Danigb](https://github.com/danigb) and [Javier Artero](https://github.com/javierartero).
+Now maintained independently.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ kramdown:
 
 <div class="svgpack-mask main-logo-svgpack" aria-label="svgpack logo"></div>
 
-[![npm](https://img.shields.io/npm/v/@marsbased/svgpack.svg?style=flat-square)](https://www.npmjs.com/package/@marsbased/svgpack)
+[![npm](https://img.shields.io/npm/v/@artero/svgpack.svg?style=flat-square)](https://www.npmjs.com/package/@artero/svgpack)
+
 
 `svgpack` converts SVG files into CSS variables and ready-to-use classes.
 
@@ -53,8 +54,11 @@ Instead of embedding SVG code directly in your HTML (which downloads the entire 
 ### Install as Project Dependency (Recommended)
 
 ```bash
-npm install @marsbased/svgpack
+npm install -D @artero/svgpack
 ```
+
+> ⚠️ Previously published as `@marsbased/svgpack`.  
+> The old package is deprecated and will no longer receive updates.
 
 ### CLI Usage
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 # Jekyll configuration for GitHub Pages
 title: svgpack
-description: Convert SVG files into CSS variables and ready-to-use classes
-author: MarsBased
+description: Generate reusable CSS, Tailwind v4 and SASS tokens from SVG icons and assets.
+author: Javier Artero
 url: https://svgpack.javierartero.com
 baseurl: ''
 
@@ -30,7 +30,7 @@ aux_links:
   "<i class='svgpack-mask  icon-github'></i> svgpack on GitHub":
     - "//github.com/javierartero/svgpack"
   "<i class='svgpack-mask  icon-npm'></i> svgpack on npm":
-    - "//www.npmjs.com/package/@marsbased/svgpack"
+    - "//www.npmjs.com/package/@artero/svgpack"
 
 # Footer
 footer_content: |

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -124,10 +124,12 @@
 
 .nav-list .nav-list-item .nav-list-link.active,
 .nav-list .nav-list-item .nav-list-link:hover {
+  color: rgba(255,255,255,.8);
+  background: none;
   background: linear-gradient(-90deg, rgba(235, 237, 245, 0.35) 0%, rgba(235, 237, 245, 0.05) 80%, rgba(235, 237, 245, .1) 100%);
 }
 
-.nav-list .nav-list-item .nav-list-link:hover {
+.nav-list .nav-list-item .nav-list-link.active {
   font-weight: 700;
 }
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -38,10 +38,22 @@ Generate SCSS functions instead of CSS variables:
 svgpack my-images/ --sass > images.scss
 ```
 
+## Tailwind v4 mode
+
+Generate output for Tailwind v4 (`@theme` and `@utility`):
+
+```bash
+svgpack my-icons/ --tailwind > svgpack.css
+```
+
+Use `--prefix <name>` to customize variable names (e.g. `--prefix icons` → `--icons-icon-search`). See [Tailwind v4](/tailwind-v4/) for details.
+
 ## CLI Options
 
 - `--background [className]` - Generate background CSS classes
-- `--mask [className]` - Generate mask CSS classes  
+- `--mask [className]` - Generate mask CSS classes
+- `--tailwind` - Generate Tailwind v4 native output (`@theme` and `@utility`)
+- `--prefix <name>` - Prefix for generated CSS variables (default: none in CSS mode; `svgpack` in `--tailwind` mode). Sanitized for CSS (e.g. spaces → hyphens).
 - `--sass` - Generate SCSS functions instead of CSS variables
 - `--help` - Show help information
 

--- a/docs/css-variables.md
+++ b/docs/css-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: CSS Variables
-nav_order: 5
+nav_order: 6
 permalink: /css-variables/
 ---
 
@@ -9,7 +9,7 @@ permalink: /css-variables/
 
 ## Simple Example
 
-Running `svgpack` against [this svg file](https://github.com/MarsBased/svgpack/blob/main/test/assets/svgpack-imagotype.svg):
+Running `svgpack` against [this svg file](https://github.com/javierartero/svgpack/blob/main/test/assets/svgpack-imagotype.svg):
 
 ```bash
 svgpack test/assets/svgpack-imagotype.svg
@@ -88,6 +88,8 @@ Simply add the class to any element:
 <!-- Custom sizing -->
 <div class="svgpack-background" style="--image: var(--my-logo); --image--width: 2em; --image--height: 2em"></div>
 ```
+
+For **Tailwind v4** integration (native `@theme` and `@utility` output), see [Tailwind v4](/tailwind-v4/).
 
 ## Advanced Usage
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,60 +9,43 @@ kramdown:
   parse_block_html: true
 ---
 
-# Installation Options
+# Installation
 
-## Project Dependency (Recommended)
+## Recommended (Build-time usage)
 
-### As Production Dependency
-
-Install as a regular dependency if you need **React components** in your application:
-
-```bash
-# npm
-npm install @marsbased/svgpack
-
-# yarn
-yarn add @marsbased/svgpack
-```
-
-Use this when:
-- **React Components**: You import and use `SvgpackBackground` or `SvgpackMask` components in your React app
-- The package needs to be available in production/runtime
-
-### As Development Dependency
-
-Install as a dev dependency if you only need **build-time SVG processing** (CSS/SCSS generation):
+Svgpack is primarily a CLI tool.  
+Install it as a dev dependency in your project:
 
 ```bash
-# npm
-npm install --save-dev @marsbased/svgpack
-
-# yarn
-yarn add --dev @marsbased/svgpack
+npm install -D @artero/svgpack
+# or
+yarn add -D @artero/svgpack
 ```
 
-Use this when:
-- **Build Scripts**: You only use svgpack to generate CSS/SCSS files during build time
-- You don't use React components
-- The package is only needed during development/build process
+> ⚠️ Previously published as `@marsbased/svgpack`.  
+> The old package is deprecated and will no longer receive updates.
 
-## Global Installation (CLI Only)
+---
 
-For one-off usage or manual processing:
+## Runtime Usage (React components)
+
+If you import `SvgpackMask` or `SvgpackBackground` directly in your React application, install it as a regular dependency:
 
 ```bash
-# npm
-npm install --global @marsbased/svgpack
-
-# yarn
-yarn global add @marsbased/svgpack
+npm install @artero/svgpack
+# or
+yarn add @artero/svgpack
 ```
 
-## Development Installation
+---
 
-To get the latest version, clone the repository and install from it:
+## Global CLI (Optional)
+
+For one-off usage outside a project:
 
 ```bash
-cd svgpack
-npm install --global .
+npm install -g @artero/svgpack
+# or
+yarn global add @artero/svgpack
 ```
+

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,7 @@ permalink: /quick-start/
 ## Install as Project Dependency (Recommended)
 
 ```bash
-npm install @marsbased/svgpack
+npm install @artero/svgpack
 ```
 
 ## CLI Usage
@@ -56,13 +56,13 @@ npm run build:svg
 ## Global Installation (Alternative)
 
 ```bash
-npm install --global @marsbased/svgpack
+npm install --global @artero/svgpack
 ```
 
 ## React Components (Optional)
 
 ```jsx
-import { SvgpackMask, SvgpackBackground } from '@marsbased/svgpack';
+import { SvgpackMask, SvgpackBackground } from '@artero/svgpack';
 
 // Use as React components
 <SvgpackMask image="my-icon" width="24px" height="24px" className="text-blue-500" />

--- a/docs/react-components.md
+++ b/docs/react-components.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: React Components
-nav_order: 4
+nav_order: 7
 permalink: /react-components/
 ---
 
@@ -12,7 +12,7 @@ svgpack includes ready-to-use React components for easy integration:
 ## Usage
 
 ```jsx
-import { SvgpackMask, SvgpackBackground } from '@marsbased/svgpack';
+import { SvgpackMask, SvgpackBackground } from '@artero/svgpack';
 
 // SvgpackMask component (great for colored icons)
 <SvgpackMask
@@ -50,7 +50,7 @@ Both components accept the following props:
 The components are fully typed and include TypeScript definitions:
 
 ```tsx
-import { SvgpackMask, SvgpackBackground } from '@marsbased/svgpack';
+import { SvgpackMask, SvgpackBackground } from '@artero/svgpack';
 
 interface MyComponentProps {
   iconName: string;

--- a/docs/tailwind-v4.md
+++ b/docs/tailwind-v4.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Tailwind CSS v4
+nav_order: 5
+permalink: /tailwind-v4/
+---
+
+# Tailwind CSS v4 Native Integration
+
+svgpack can generate output tailored for **Tailwind v4**, using `@theme` and `@utility` so your SVG variables and utilities are consumed natively by Tailwind’s pipeline.
+
+## Generate Tailwind output
+
+Use the `--tailwind` flag:
+
+```bash
+svgpack my-icons/ --tailwind > svgpack.css
+```
+
+Then import the file in your Tailwind setup (e.g. in your main CSS or via `@import` in Tailwind v4).
+
+<a href="https://play.tailwindcss.com/z4448csf2i" target="_blank" rel="noopener noreferrer">Play Tailwind CSS Example</a>
+
+## What you get
+
+- **`@theme { ... }`** — Your SVG URLs are emitted as theme variables (e.g. `--svgpack-icon-search: url("...")`), so Tailwind can use them as design tokens.
+- **`@utility svgpack-*`** — Maps the theme variable for the current utility to `--svgpack-image` (used by the mask and background utilities).
+- **`@utility svgpack-mask`** — Mask-based icon utility (color, size, and dimensions configurable via CSS variables).
+- **`@utility svgpack-bg`** — Background-based image utility.
+
+Unused utilities are tree-shaken from the final CSS, so all of them can be emitted without affecting bundle size.
+
+## Prefix
+
+In Tailwind mode, variable names use the **`svgpack`** prefix by default (e.g. `--svgpack-icon-search`). This avoids collisions with other theme tokens.
+
+You can override the prefix with `--prefix`:
+
+```bash
+# Custom prefix for variable names
+svgpack my-icons/ --tailwind --prefix icons > svgpack.css
+```
+
+This produces variables like `--icons-icon-search`. The `--prefix` option applies in **all modes** (standard CSS and Tailwind). Prefix values are sanitized for use in CSS: spaces become hyphens, and invalid characters are removed.
+
+## Using the utilities
+
+Set the image (and optional overrides) with CSS variables, then apply the utility class:
+
+```html
+<div class="svgpack-mask svgpack-icon-search size-6 text-neutral-500"></div>
+
+<div 
+  class="svgpack-bg svgpack-my-logo" 
+  style="--svgpack-width:300px;--svgpack-height:140px;"
+></div>
+```
+
+Variables like `--image`, `--image--color`, `--image--width`, and `--image--height` are supported for backward compatibility; the new prefixed names (e.g. `--svgpack-color`, `--svgpack-width`) are the recommended API going forward.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@marsbased/svgpack",
+  "name": "@artero/svgpack",
   "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@marsbased/svgpack",
+      "name": "@artero/svgpack",
       "version": "2.1.9",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@marsbased/svgpack",
+  "name": "@artero/svgpack",
   "version": "2.1.9",
-  "description": "Convert SVG files into CSS variables",
+  "description": "Generate reusable CSS, Tailwind v4 and SASS tokens from SVG icons and assets.",
   "repository": "git@github.com:JavierArtero/svgpack.git",
   "author": "Javier Artero",
   "license": "MIT",

--- a/src/help.js
+++ b/src/help.js
@@ -10,18 +10,22 @@ const HELP = `
   -v, --version                       output the version number
   -r, --no-replace                    skip replace-str function from output
   --css, --css-vars                   generate CSS variables (default)
+  --tailwind                          Tailwind v4 native output (@theme / @utility)
   --sass                              generate SCSS functions instead of CSS variables
-  --background [class-name]           generate CSS classes for background usage
-  --mask [class-name]                 generate CSS classes for mask usage
+  --prefix <name>                     Prefix for generated CSS variables.
+                                      Default: none (CSS mode), "svgpack" (--tailwind mode)
+  --mask [class-name]                 Generate mask utility class (default: svgpack-mask)
+  --background [class-name]           Generate background utility class (legacy default: svgpack-background)
 
   Examples:
     \`svgpack .\`                      pack all svg files in the current folder as CSS variables
     \`svgpack my-icons/ > icons.css\`  output to file
-    \`svgpack . --background\`         generate CSS variables with background class
-    \`svgpack . --background my-icon\` generate CSS variables with custom background class
+    \`svgpack . --tailwind\`           Tailwind v4 native output (@theme and @utility)
+    \`svgpack . --sass\`               pack all svg files as SCSS functions
     \`svgpack . --mask\`               generate CSS variables with mask class
     \`svgpack . --mask my-mask\`       generate CSS variables with custom mask class
-    \`svgpack . --sass\`               pack all svg files as SCSS functions
+    \`svgpack . --background\`         generate CSS variables with background class
+    \`svgpack . --background my-icon\` generate CSS variables with custom background class
 `;
 
 function printVersion() {

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -1,7 +1,7 @@
 /**
  * To give support IE browser must change some characters
  *
- * @see https://github.com/MarsBased/svgpack/issues/1
+ * @see https://github.com/javierartero/svgpack/issues/1
  * @see https://codepen.io/jakob-e/pen/doMoML
  *
  * @params {Object} options

--- a/src/svg-to-css.js
+++ b/src/svg-to-css.js
@@ -7,22 +7,24 @@ module.exports = function (options = {}) {
   const optimize = optimizer(options.optimizer);
   const sanitize = options.sanitize === false ? (x) => x : sanitizer();
 
+  const prefix = options.effectivePrefix ?? '';
+
   return function toCssVariable(filename) {
     const name = toSlugCase(basename(filename, '.svg'));
 
     return function (svg) {
       return optimize(svg.toString()).then((optimized) => {
         const sanitizedSvg = sanitize(optimized);
-        return template(name, sanitizedSvg);
+        return template(name, sanitizedSvg, prefix);
       });
     };
   };
 };
 
-function template(name, svg) {
+function template(name, svg, prefix = '') {
   const encodedSvg = svg.replace(/#/g, '%23').replace(/\s+/g, ' ').trim();
-
-  const output = `  --${name}: url("data:image/svg+xml,${encodedSvg}");\n`;
+  const varName = prefix ? `${prefix}-${name}` : name;
+  const output = `  --${varName}: url("data:image/svg+xml,${encodedSvg}");\n`;
 
   return output;
 }


### PR DESCRIPTION
## Changes

- **CLI and output modes:**
  - New `--tailwind` flag for Tailwind v4–native output (`@theme` and `@utility`).
  - New `--prefix <name>` option for variable names (all modes); default `svgpack` in Tailwind mode.
  - Mutually exclusive modes: only one of `--css`, `--sass`, or `--tailwind` per run; CLI errors if multiple are set.
  - Help text updated with `--tailwind`, `--prefix`, and `--bg` alias; examples reordered.

- **Tailwind mode output:**
  - Variables emitted inside `@theme { }` instead of `:root`.
  - Token selector `@utility svgpack-*` with `--value(--prefix-*)` based on effective prefix.
  - `@utility svgpack-mask` and `@utility svgpack-bg` with `var(--image, var(--svgpack-image))` and shared size/color/width/height fallbacks.
  - CSS block formatting: no extra blank line before `}`; single newline after `}` (applied to both `:root` and `@theme`).

- **Standard CSS mode alignment:**
  - `buildStandardCssOutput`: `.svgpack-background` and `.svgpack-mask` use the same variable pattern as Tailwind utilities (`--svgpack-image`, `--svgpack-bg-size`, `--svgpack-mask-size`, `--svgpack-color`, `--svgpack-width`, `--svgpack-height` with legacy `--image` / `--image--*` fallbacks).
  - `-webkit-mask` added to mask class for compatibility.

- **Prefix and sanitization:**
  - `getEffectivePrefix(options)`: default `svgpack` when `--tailwind` and no `--prefix`; otherwise uses sanitized `--prefix`.
  - `sanitizeCssPrefix(value)`: trim, spaces → hyphens, strip invalid chars, trim leading/trailing hyphens/underscores.
  - Prefixed variable names applied in `svg-to-css` template and in Tailwind token selector.

- **Tests:**
  - Bin tests for `--tailwind` output (`@theme`, `@utility svgpack-*`, `svgpack-mask`, `svgpack-bg`, default prefixed vars).
  - Tests for `--tailwind --prefix` custom prefix and for standard mode unchanged (no `@theme`/`@utility`).
  - Tests for prefix sanitization (spaces → hyphens; leading/trailing and invalid chars removed).
  - Bin tests use `execFileSync` with path array so paths with spaces work.

- **Documentation:**
  - New `docs/tailwind-v4.md`: how to run with `--tailwind`, what you get, prefix behavior, usage examples, one mode at a time.
  - `docs/cli-usage.md`: Tailwind v4 mode section and `--tailwind` / `--prefix` in CLI options.
  - `docs/css-variables.md`: link to Tailwind v4; `docs/installation.md` simplified and deprecation notice added.
  - Sidebar order: Tailwind v4 above CSS Variables and SCSS (nav_order 5, 6, 7).
  - README: Tailwind v4 in table of contents and Quick Start example.

- **Publication:**
  - All references to `@marsbased/svgpack` replaced with `@artero/svgpack` (README, docs, badges, install commands, npm link in config).
  - Deprecation notice after install: "Previously published as @marsbased/svgpack. The old package is deprecated and will no longer receive updates."
  - New **Origins** section at end of README (MarsBased origins, Danigg & Javier Artero, maintained independently).
  - `package.json`: name `@artero/svgpack`, version and description updated.

## Files Modified

- `.vscode/settings.json`: Project/editor settings updates.
- `LICENSE`: Year or copyright update.
- `README.md`: Badge and install to `@artero/svgpack`; deprecation notice after install; Tailwind v4 in TOC and Quick Start; Origins section before License.
- `docs/README.md`: Package name and install example to `@artero/svgpack`.
- `docs/_config.yml`: npm package link to `@artero/svgpack`.
- `docs/_sass/custom/custom.scss`: Theme/style tweaks for docs.
- `docs/cli-usage.md`: Tailwind v4 mode section; `--tailwind` and `--prefix` in CLI options.
- `docs/css-variables.md`: Link to Tailwind v4; nav_order 6.
- `docs/installation.md`: All install commands to `@artero/svgpack`; deprecation notice; content reflow.
- `docs/quick-start.md`: Package name to `@artero/svgpack`.
- `docs/react-components.md`: Import examples to `@artero/svgpack`.
- `docs/tailwind-v4.md`: New page (nav_order 5) with Tailwind v4 usage, prefix, and examples.
- `package-lock.json`: Lockfile updates for package name/version.
- `package.json`: Name `@artero/svgpack`, version 2.2.0, description updated.
- `src/help.js`: Options and examples for `--tailwind`, `--prefix`, `--bg`.
- `src/pack.js`: Mode selection and validation; `getEffectivePrefix`, `sanitizeCssPrefix`; `buildStandardCssOutput` and `buildTailwindCssOutput` with formatting; `@theme` and `@utility` blocks; standard classes aligned with new variables.
- `src/sanitizer.js`: Minor fix or dependency.
- `src/svg-to-css.js`: Accept `effectivePrefix` and pass to template; variable name with optional prefix.
- `test/bin.spec.js`: New tests for Tailwind output, custom prefix, standard mode unchanged, prefix sanitization; use `execFileSync` for path arguments.

Closes #23
